### PR TITLE
Converter configuration settings

### DIFF
--- a/CK2ToEU3/Converter Mod/country_mappings_mod.txt
+++ b/CK2ToEU3/Converter Mod/country_mappings_mod.txt
@@ -246,6 +246,7 @@ link = { CK2 = d_tripolitania EU3 = TRP } # Tripoli
 link = { CK2 = d_mali EU3 = MAL } # Mali
 link = { CK2 = d_songhay EU3 = SON } # Songhai
 link = { CK2 = d_harer EU3 = ADA } # Harer => Adal
+link = { CK2 = d_sibir EU3 = SIB } # Sibir
 
 # Holy Orders
 link = { CK2 = d_teutonic_order EU3 = TEU } # Teutonic Order

--- a/CK2ToEU3/Converter Mod/mod/Converter/decisions/ck2empires.txt
+++ b/CK2ToEU3/Converter Mod/mod/Converter/decisions/ck2empires.txt
@@ -592,13 +592,19 @@ country_decisions = {
 			NOT = { exists = ABY }
 		}
 		allow = {
-			OR = {
-				NOT = { exists = ETH }
-				tag = ETH
-			}
-			OR = {
-				NOT = { exists = ADA }
-				tag = ADA
+			AND = {
+				OR = {
+					NOT = { exists = ETH }
+					tag = ETH
+				}
+				OR = {
+					NOT = { exists = ADA }
+					tag = ADA
+				}
+				OR = {
+					NOT = { government = imperial_government }
+					NOT = { tag = ETH }
+				}
 			}
 			owns = 1206 # Majerteen
 			owns = 1224 # Gonder

--- a/CK2ToEU3/Data Files/country_mappings.txt
+++ b/CK2ToEU3/Data Files/country_mappings.txt
@@ -246,6 +246,7 @@ link = { CK2 = d_tripolitania EU3 = TRP } # Tripoli
 link = { CK2 = d_mali EU3 = MAL } # Mali
 link = { CK2 = d_songhay EU3 = SON } # Songhai
 link = { CK2 = d_harer EU3 = ADA } # Harer => Adal
+link = { CK2 = d_sibir EU3 = SIB } # Sibir
 
 # Holy Orders
 link = { CK2 = d_teutonic_order EU3 = TEU } # Teutonic Order


### PR DESCRIPTION
1. Country conversion: Duchy of Sibir (d_sibir) is mapped to SIB country tag
2. Restore Abyssinian Empire Decision: Disable if nation is ETH with imperial government because they are the same entity