### PR TITLE
Fix for bug in custom focus trees

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4Focus.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Focus.cpp
@@ -161,6 +161,22 @@ HoI4Focus* HoI4Focus::makeCustomizedCopy(const string& country) const
 	newFocus->prerequisites.clear();
 	for (auto prerequisite: prerequisites)
 	{
+		//have to account for several foci in one prerequisite, so need to look for occurences of " focus" and insert country before that
+		int stringPosition = 0;
+		do
+		{
+			int focusPosition = prerequisite.find(" focus", stringPosition);
+			if (focusPosition != string::npos)
+			{
+				prerequisite.insert(focusPosition, country);
+				stringPosition = focusPosition + country.size() + 6;
+			}
+			else
+			{
+				stringPosition = prerequisite.size();
+			}
+		}
+		while(stringPosition < prerequisite.size());
 		newFocus->prerequisites.push_back(prerequisite + country);
 	}
 

--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
@@ -1657,8 +1657,7 @@ void HoI4FocusTree::addVersion1_0GenericFocusTree()
 	newFocus = new HoI4Focus;
 	newFocus->id = "ideological_fanaticism";
 	newFocus->icon = "GFX_goal_generic_demand_territory";
-	newFocus->prerequisites.push_back("focus = paramilitarism");
-	newFocus->prerequisites.push_back("focus = political_commissars");
+	newFocus->prerequisites.push_back("focus = paramilitarism focus = political_commissars");
 	newFocus->xPos = 17;
 	newFocus->yPos = 6;
 	newFocus->cost = 10;
@@ -1675,8 +1674,7 @@ void HoI4FocusTree::addVersion1_0GenericFocusTree()
 	newFocus = new HoI4Focus;
 	newFocus->id = "technology_sharing";
 	newFocus->icon = "GFX_goal_generic_scientific_exchange";
-	newFocus->prerequisites.push_back("focus = ideological_fanaticism");
-	newFocus->prerequisites.push_back("focus = why_we_fight");
+	newFocus->prerequisites.push_back("focus = ideological_fanaticism focus = why_we_fight");
 	newFocus->available += "			has_war = yes\n";
 	newFocus->available += "			is_in_faction = yes\n";
 	newFocus->available += "			OR = {\n";

--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
@@ -3368,8 +3368,7 @@ void HoI4FocusTree::addVersion1_3GenericFocusTree()
 	newFocus = new HoI4Focus;
 	newFocus->id = "ideological_fanaticism";
 	newFocus->icon = "GFX_goal_generic_demand_territory";
-	newFocus->prerequisites.push_back("focus = paramilitarism");
-	newFocus->prerequisites.push_back("focus = political_commissars");
+	newFocus->prerequisites.push_back("focus = paramilitarism focus = political_commissars");
 	newFocus->xPos = 17;
 	newFocus->yPos = 6;
 	newFocus->cost = 10;
@@ -3387,8 +3386,7 @@ void HoI4FocusTree::addVersion1_3GenericFocusTree()
 	newFocus = new HoI4Focus;
 	newFocus->id = "technology_sharing";
 	newFocus->icon = "GFX_goal_generic_scientific_exchange";
-	newFocus->prerequisites.push_back("focus = ideological_fanaticism");
-	newFocus->prerequisites.push_back("focus = why_we_fight");
+	newFocus->prerequisites.push_back("focus = ideological_fanaticism focus = why_we_fight");
 	newFocus->available += "			has_war = yes\n";
 	newFocus->available += "			is_in_faction = yes\n";
 	newFocus->available += "			OR = {\n";


### PR DESCRIPTION
Corrected generic focus tree creation methods in HoI4FocusTree.cpp (foci which had several foci to choose one from as prerequisite instead of requiring all were wrong).
Improved HoI4Focus::makeCustomizedCopy method in HoIFocus.cpp, so that it copies such prerequisites correctly with the country suffix for each focus in the prerequisite field.

Sorry for the three commits, I was a bit overeager.