### PR TITLE
Changed Great Power War foci for Fascists, Communists and Absolutists…

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
@@ -1280,7 +1280,7 @@ vector<HoI4Faction*> HoI4WarCreator::fascistWarMaker(HoI4Country* Leader, ofstre
 					newFocus->aiWillDo += "			}";
 				}
 				newFocus->completionReward += "			add_named_threat = { threat = 3 name = " + newFocus->id + " }\n";
-				newFocus->completionReward += "			create_wargoal = {\n";
+				newFocus->completionReward += "			declare_war_on = {\n";
 				newFocus->completionReward += "				type = annex_everything\n";
 				newFocus->completionReward += "				target = " + GC->getTag() + "\n";
 				newFocus->completionReward += "			}";
@@ -1804,7 +1804,7 @@ vector<HoI4Faction*> HoI4WarCreator::communistWarCreator(HoI4Country* Leader, of
 
 
 				newFocus->completionReward += "			add_named_threat = { threat = 5 name = " + newFocus->id + " }\n";
-				newFocus->completionReward += "			create_wargoal = {\n";
+				newFocus->completionReward += "			declare_war_on = {\n";
 				newFocus->completionReward += "				type = puppet_wargoal_focus\n";
 				newFocus->completionReward += "				target = " + GC->getTag() + "\n";
 				newFocus->completionReward += "			}";
@@ -2179,7 +2179,7 @@ vector<HoI4Faction*> HoI4WarCreator::addGreatPowerWars(HoI4Country* country, HoI
 				newFocus->aiWillDo += "			}";
 			}
 			newFocus->completionReward += "			add_named_threat = { threat = 5 name = " + newFocus->id + " }\n";
-			newFocus->completionReward += "			create_wargoal = {\n";
+			newFocus->completionReward += "			declare_war_on = {\n";
 			newFocus->completionReward += "				type = annex_everything\n";
 			newFocus->completionReward += "				target = " + target->getTag() + "\n";
 			newFocus->completionReward += "			}";


### PR DESCRIPTION
… to give an immediate declaration of war instead of just a war goal.

It's a bit blunt, but the war creator tries to anticipate if the target is feasible. Without this I still got games where the Great War didn't happen.

Next I will write code to vary the start dates of some foci a bit more depending on relations, so that all big and small wars don't break out at the same time. Countries with bad relations from Vic2 should go to war earlier.