### PR TITLE
Neighbor war foci will now have a varying starting date depending on …

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
@@ -36,7 +36,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 
 void HoI4WarCreator::generateWars(HoI4World* world)
 {
-	string testDate = delayedDate("1935.03.16", 1000);
 	theWorld = world;
 
 	ofstream AILog("AI-log.txt");
@@ -223,19 +222,6 @@ bool HoI4WarCreator::isImportantCountry(HoI4Country * country)
 		return true;
 	}
 	return false;
-}
-
-string HoI4WarCreator::delayedDate(string startDate, int delayDays)
-{
-	using namespace boost::gregorian;
-	boost::gregorian::date codedDate;
-	codedDate = from_string(startDate);
-	date_duration delayDuration(delayDays);
-	boost::gregorian::date resultDate = codedDate + delayDuration;
-	string resultString = to_iso_extended_string(resultDate);
-	resultString[4] = '.';
-	resultString[7] = '.';
-	return resultString;
 }
 
 vector<HoI4Country*> HoI4WarCreator::findEvilCountries()
@@ -1920,6 +1906,8 @@ vector<HoI4Faction*> HoI4WarCreator::neighborWarCreator(HoI4Country * country, o
 		}
 
 		set<string> Allies = country->getAllies();
+		date startDate = date("1937.01.01");
+		startDate.delayedByMonths(-0.25 * relations);
 		if (Allies.find(target->getTag()) == Allies.end())
 		{
 			countriesAtWar.push_back(findFaction(country));
@@ -1931,7 +1919,7 @@ vector<HoI4Faction*> HoI4WarCreator::neighborWarCreator(HoI4Country * country, o
 			newFocus->text = "War with " + target->getSourceCountry()->getName("english");//change to faction name later
 			newFocus->prerequisites.push_back("focus =  MilitaryBuildup" + country->getTag());
 			newFocus->available = "			has_war = no\n";
-			newFocus->available += "			date > " + delayedDate("1937.1.1", 1600 + 8 * relations);
+			newFocus->available += "			date > " + startDate.toString();
 			newFocus->xPos = 24;
 			newFocus->yPos = 0;
 			newFocus->cost = 10;

--- a/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
@@ -36,6 +36,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 
 void HoI4WarCreator::generateWars(HoI4World* world)
 {
+	string testDate = delayedDate("1935.03.16", 1000);
 	theWorld = world;
 
 	ofstream AILog("AI-log.txt");
@@ -224,6 +225,18 @@ bool HoI4WarCreator::isImportantCountry(HoI4Country * country)
 	return false;
 }
 
+string HoI4WarCreator::delayedDate(string startDate, int delayDays)
+{
+	using namespace boost::gregorian;
+	boost::gregorian::date codedDate;
+	codedDate = from_string(startDate);
+	date_duration delayDuration(delayDays);
+	boost::gregorian::date resultDate = codedDate + delayDuration;
+	string resultString = to_iso_extended_string(resultDate);
+	resultString[4] = '.';
+	resultString[7] = '.';
+	return resultString;
+}
 
 vector<HoI4Country*> HoI4WarCreator::findEvilCountries()
 {
@@ -1279,7 +1292,7 @@ vector<HoI4Faction*> HoI4WarCreator::fascistWarMaker(HoI4Country* Leader, ofstre
 					newFocus->aiWillDo += "				}\n";
 					newFocus->aiWillDo += "			}";
 				}
-				newFocus->completionReward += "			add_named_threat = { threat = 3 name = " + newFocus->id + " }\n";
+				newFocus->completionReward += "			add_named_threat = { threat = 5 name = " + newFocus->id + " }\n";
 				newFocus->completionReward += "			declare_war_on = {\n";
 				newFocus->completionReward += "				type = annex_everything\n";
 				newFocus->completionReward += "				target = " + GC->getTag() + "\n";
@@ -1918,7 +1931,7 @@ vector<HoI4Faction*> HoI4WarCreator::neighborWarCreator(HoI4Country * country, o
 			newFocus->text = "War with " + target->getSourceCountry()->getName("english");//change to faction name later
 			newFocus->prerequisites.push_back("focus =  MilitaryBuildup" + country->getTag());
 			newFocus->available = "			has_war = no\n";
-			newFocus->available += "			date > 1940.1.1";
+			newFocus->available += "			date > " + delayedDate("1937.1.1", 1600 + 8 * relations);
 			newFocus->xPos = 24;
 			newFocus->yPos = 0;
 			newFocus->cost = 10;
@@ -1943,7 +1956,7 @@ vector<HoI4Faction*> HoI4WarCreator::neighborWarCreator(HoI4Country * country, o
 				newFocus->aiWillDo += "				}\n";
 				newFocus->aiWillDo += "			}";
 			}
-			newFocus->completionReward += "			add_named_threat = { threat = 5 name = " + newFocus->id + " }\n";
+			newFocus->completionReward += "			add_named_threat = { threat = 3 name = " + newFocus->id + " }\n";
 			newFocus->completionReward += "			create_wargoal = {\n";
 			newFocus->completionReward += "				type = annex_everything\n";
 			newFocus->completionReward += "				target = " + target->getTag() + "\n";

--- a/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.h
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.h
@@ -24,7 +24,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 #include <fstream>
 #include <map>
 #include <string>
-#include <boost/date_time/gregorian/gregorian.hpp>
 #include "HoI4Country.h"
 using namespace std;
 
@@ -49,7 +48,6 @@ class HoI4WarCreator
 		double calculatePercentOfWorldAtWar(ofstream& AILog, const set<HoI4Faction*>& factionsAtWar, double worldStrength);
 		void generateAdditionalWars(ofstream& AILog, set<HoI4Faction*>& factionsAtWar, double worldStrength);
 		bool isImportantCountry(HoI4Country* country);
-		string delayedDate(string startDate, int delayDays);
 
 		vector<HoI4Faction*> fascistWarMaker(HoI4Country* country, ofstream& AILog);
 		vector<HoI4Faction*> communistWarCreator(HoI4Country* country, ofstream& AILog);

--- a/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.h
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.h
@@ -24,6 +24,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 #include <fstream>
 #include <map>
 #include <string>
+#include <boost/date_time/gregorian/gregorian.hpp>
 #include "HoI4Country.h"
 using namespace std;
 
@@ -48,6 +49,7 @@ class HoI4WarCreator
 		double calculatePercentOfWorldAtWar(ofstream& AILog, const set<HoI4Faction*>& factionsAtWar, double worldStrength);
 		void generateAdditionalWars(ofstream& AILog, set<HoI4Faction*>& factionsAtWar, double worldStrength);
 		bool isImportantCountry(HoI4Country* country);
+		string delayedDate(string startDate, int delayDays);
 
 		vector<HoI4Faction*> fascistWarMaker(HoI4Country* country, ofstream& AILog);
 		vector<HoI4Faction*> communistWarCreator(HoI4Country* country, ofstream& AILog);

--- a/common_items/Date.cpp
+++ b/common_items/Date.cpp
@@ -225,6 +225,18 @@ float date::diffInYears(const date& _rhs) const
 	return years;
 }
 
+void date::delayedByMonths(const int _months)
+{
+	year += _months / 12;
+	month += _months % 12;
+	if (month > 12)
+	{
+		year++;
+		month -= 12;
+	}
+	return;
+}
+
 bool date::isSet() const
 {
 	const date default_date;	// an instance with the default date

--- a/common_items/Date.h
+++ b/common_items/Date.h
@@ -50,6 +50,7 @@ struct date
 	friend ostream& operator<<(ostream&, const date&);
 	
 	float diffInYears(const date& _rhs) const;
+	void delayedByMonths(const int _months);
 
 	bool isSet() const;
 	string toString() const;


### PR DESCRIPTION
…the relations of the involved countries.

This is a bit of a mess: I use date classes from the boost library. I saw that we already have a date class among the common items. If you want I can take a look to make my little helper function a method of the existing class, but that class thus far did work without the boost library.

Other stuff: Currently some national foci are defined in the National Focus class and some in the War Creator. Ugly, I should move those all to the National Focus class.
And I start to wonder how I support localization. Can you recommend a class which contains a nice example how to implement this?