### PR TITLE
Refined prerequisites and bypasses of war foci.

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4FocusTree.cpp
@@ -3536,6 +3536,7 @@ void HoI4FocusTree::addDemocracyNationalFocuses(HoI4Country* Home, vector<HoI4Co
 		newFocus->xPos = XStart + offBalance + warPlannumber * 2;
 		newFocus->yPos = 2;
 		newFocus->cost = 10;
+		newFocus->bypass += "					has_war_with = " + Country->getTag() + "\n";
 		newFocus->aiWillDo += "			factor = 10";
 		newFocus->completionReward += "			army_experience = 20\n";
 		newFocus->completionReward += "			add_tech_bonus = {\n";
@@ -3565,6 +3566,7 @@ void HoI4FocusTree::addDemocracyNationalFocuses(HoI4Country* Home, vector<HoI4Co
 		newFocus->xPos = XStart + offBalance + warPlannumber * 2;
 		newFocus->yPos = 3;
 		newFocus->cost = 10;
+		newFocus->bypass += "					has_war_with = " + Country->getTag() + "\n";
 		newFocus->aiWillDo += "			factor = 10";
 		newFocus->completionReward += "			" + Country->getTag() + " = {\n";
 		newFocus->completionReward += "				add_opinion_modifier = { target = " + Home->getTag() + " modifier = embargo }\n";
@@ -3576,6 +3578,7 @@ void HoI4FocusTree::addDemocracyNationalFocuses(HoI4Country* Home, vector<HoI4Co
 		newFocus->id = "WAR" + Home->getTag() + Country->getTag();
 		newFocus->icon = "GFX_goal_support_democracy";
 		newFocus->text += "Enact War Plan " + Country->getSourceCountry()->getName("english");
+		newFocus->available += "						has_war = no\n";
 		newFocus->available += "			any_other_country = {";
 		newFocus->available += "						original_tag = " + Country->getTag();
 		newFocus->available += "						exists = yes";
@@ -3591,8 +3594,9 @@ void HoI4FocusTree::addDemocracyNationalFocuses(HoI4Country* Home, vector<HoI4Co
 		newFocus->xPos = XStart + offBalance + warPlannumber++ * 2;
 		newFocus->yPos = 4;
 		newFocus->cost = 10;
+		newFocus->bypass += "					has_war_with = " + Country->getTag() + "\n";
 		newFocus->aiWillDo += "			factor = 10";
-		newFocus->completionReward += "			create_wargoal = {\n";
+		newFocus->completionReward += "			declare_war_on = {\n";
 		newFocus->completionReward += "				type = puppet_wargoal_focus\n";
 		newFocus->completionReward += "				target = " + Country->getTag() + "\n";
 		newFocus->completionReward += "			}";

--- a/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4WarCreator.cpp
@@ -981,6 +981,7 @@ vector<HoI4Faction*> HoI4WarCreator::fascistWarMaker(HoI4Country* Leader, ofstre
 					newFocus->yPos     = 1;
 				}
 				newFocus->cost     = 10;
+				newFocus->bypass += "  has_war_with = " + nan[i]->getTag() + "\n";
 				newFocus->aiWillDo = "	factor = 10\n";
 				newFocus->aiWillDo += "	modifier = {\n";
 				newFocus->aiWillDo += "		factor = 0\n";
@@ -1022,6 +1023,7 @@ vector<HoI4Faction*> HoI4WarCreator::fascistWarMaker(HoI4Country* Leader, ofstre
 				newFocus->aiWillDo += "		factor = 0\n";
 				newFocus->aiWillDo += "		date < 1937.6.6\n";
 				newFocus->aiWillDo += "	}";
+				newFocus->bypass += "		has_war_with = " + nan[i]->getTag() + "\n";
 				newFocus->completionReward += "			add_named_threat = { threat = 3 name = " + newFocus->id + " }\n";
 				newFocus->completionReward += "			create_wargoal = {\n";
 				newFocus->completionReward += "				type = annex_everything\n";
@@ -1277,6 +1279,7 @@ vector<HoI4Faction*> HoI4WarCreator::fascistWarMaker(HoI4Country* Leader, ofstre
 					newFocus->aiWillDo += "				}\n";
 					newFocus->aiWillDo += "			}";
 				}
+				newFocus->bypass += "		has_war_with = " + GC->getTag() + "\n";
 				newFocus->completionReward += "			add_named_threat = { threat = 5 name = " + newFocus->id + " }\n";
 				newFocus->completionReward += "			declare_war_on = {\n";
 				newFocus->completionReward += "				type = annex_everything\n";
@@ -1555,6 +1558,7 @@ vector<HoI4Faction*> HoI4WarCreator::communistWarCreator(HoI4Country* Leader, of
 				newFocus->xPos     = takenSpots.back() + 3 + i * 2;
 				newFocus->yPos     = 2;
 				newFocus->cost     = 10;
+				newFocus->bypass += "					has_war_with = " + TargetsbyIC[i]->getTag() + "\n";
 				newFocus->aiWillDo = "			factor = 5\n";
 				newFocus->aiWillDo += "			modifier = {\n";
 				newFocus->aiWillDo += "				factor = 0\n";
@@ -1775,6 +1779,7 @@ vector<HoI4Faction*> HoI4WarCreator::communistWarCreator(HoI4Country* Leader, of
 				newFocus->yPos     = y2 + maxGCAlliance;
 				//newFocus->yPos     = takenSpotsy.back() + 1;
 				newFocus->cost     = 10;
+				newFocus->bypass += "		   has_war_with = " + GC->getTag() + "\n";
 				newFocus->aiWillDo = "			factor = " + to_string(10 - maxGCWars * 5) + "\n";
 				newFocus->aiWillDo += "			modifier = {\n";
 				newFocus->aiWillDo += "					factor = 0\n";
@@ -1921,6 +1926,7 @@ vector<HoI4Faction*> HoI4WarCreator::neighborWarCreator(HoI4Country * country, o
 			newFocus->xPos = 24;
 			newFocus->yPos = 0;
 			newFocus->cost = 10;
+			newFocus->bypass += "          has_war_with = " + target->getTag() + "\n";
 			newFocus->aiWillDo = "			factor = " + to_string(10 - numWarsWithNeighbors * 5) + "\n";
 			newFocus->aiWillDo += "			modifier = {\n";
 			newFocus->aiWillDo += "				factor = 0\n";


### PR DESCRIPTION
Small improvements to the war foci before I am off for a few days to PDXCon. I recommend merging this if there is a close release, since it's a bit stupid when a nation wastes time with a war focus for a target they are already in war with.
When I am back I want to do some bigger refactoring with the foci (move the foci themselves to the FocusTree and Focus classes).