### PR TITLE
Added linux implementation of TryCreateFolder and GetCurrentDirectory

### DIFF
--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -26,7 +26,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 #include <cstdarg>
 #include <cstring>
 #include <iostream>
-#include <algorithm>
 
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
I've added an implementation for TryCreateFolder that recursively creates all needed folders for a given path.
It creates a folder and gives the user and the user's group read/write/list permissions on the folder

I've also implemented GetCurrentDirectory to return the current process's directory.

Both functions have been tested in a stub project since I could not test it in the converter itself because the other FS functions  are not yet implemented. I did test compilation and linking within the converter project.

I've tested the functionality itself on Linux Mint 17.2 (ubuntu 14.04) and Debian 8.

If I need to change aspects of the code or need to change the code style I'd be happy to oblige.