### PR TITLE
linux file listing methods and linux file copy method

### DIFF
--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -32,6 +32,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <limits.h>
+#include <dirent.h>
 
 using namespace std;
 
@@ -166,23 +167,50 @@ namespace Utils
         	}
 	}
 
+	bool IsRegularFile(const std::string &path)
+	{
+		struct stat status;
+        	if(stat(path.c_str(), &status) != 0))
+		{
+			retrun S_ISREG(status.st_mode);
+		}else{
+			LOG(LogLevel::Error) << "unable to check for regular file: " << path;
+			return false;
+		}
+	}
+	
 	void GetAllFilesInFolder(const std::string& path, std::set<std::string>& fileNames)
 	{
-		char directory[MAX_PATH];
-		LOG(LogLevel::Error) << "GetAllFilesInFolder() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
-		/*DIR *dp;
-		if ((dp	 = opendir(path.c_str())) == NULL)
+		using namespace std;
+		DIR *dir = opendir(path.c_str());
+		if(dir == NULL)
 		{
-			return;
+			if(errno == EACCES)
+			{
+				LOG(LogLevel::Error) << "no permission to read directory: " << path;
+			}else if(errno == ENOENT)
+			{
+				LOG(LogLevel::Error) << "directory does not exist: " << path;
+			}else if(errno == ENOTDIR)
+			{
+				LOG(LogLevel::Error) << "path is not a directory: " << path;
+			}else{
+				LOG(LogLevel::Error) << "unable to open directory: " << path;
+			}
+		}else{
+			struct dirent *dirent_ptr;
+			while((dirent_ptr = read_dir(dir)) != NULL){
+				string fileName{dirent_ptr->name};
+				if(IsRegularFile(path+fileName)){
+					fileNames.insert(fileName);
+				}
+			}
+			if(errno != 0){
+				fileNames.clear();
+				LOG(LogLevel::Error) << "an error occurred hile trying to list files in path: " << path;
+			}
+			closedir(dir);
 		}
-
-		struct dirent *dirp;
-		while ((dirp = readdir(dp)) != NULL)
-		{
-			fileNames.insert(std::string(dirp->d_name));
-		}
-		closedir(dp);*/
 	}
 
 	void GetAllFilesInFolderRecursive(const std::string& path, std::set<std::string>& filenames)

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -322,7 +322,7 @@ namespace Utils
         {
                 using namespace std;
                 int inputHandle = open(sourcePath.c_str(), O_RDONLY);
-                if(inputHandle == 0)
+                if(inputHandle == -1)
                 {
                         LOG(LogLevel::Error) << "unable to open copy source path: " << sourcePath;
                         return false;
@@ -339,7 +339,7 @@ namespace Utils
                         return false;
                 }
                 int outputHandle = open(destPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, inputStat.st_mode);
-                if(outputHandle == 0)
+                if(outputHandle == -1)
                 {
                         LOG(LogLevel::Error) << "unable to open copy destination file: " << destPath;
                         close(inputHandle);
@@ -381,14 +381,14 @@ namespace Utils
 
 	bool DoesFileExist(const std::string& path)
 	{
-		LOG(LogLevel::Error) << "DoesFileExist() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
+		mode_t mode;
+		return GetFileMode(path, mode) && S_ISREG(mode);
 	}
 
 	bool doesFolderExist(const std::string& path)
 	{
-		LOG(LogLevel::Error) << "doesFolderExist() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
+		mode_t mode;
+		return GetFileMode(path, mode) && S_ISDIR(mode);
 	}
 
 	void WriteToConsole(LogLevel level, const std::string& logMessage)

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -348,7 +348,10 @@ namespace Utils
                 ssize_t remaining = inputStat.st_size;
                 while(remaining > 0)
                 {
-                        ssize_t copied = sendfile(outputHandle, inputHandle, NULL, remaining);
+        		// Copy file using sendfile because this is more efficient since copy is done in kernelspace
+			// Won't work in kernels older than 2.6.33 (glibc 2.1)
+			// If such systems must be supported, this method should be reimplemented using POSIX read/write methods or iostreams
+	               ssize_t copied = sendfile(outputHandle, inputHandle, NULL, remaining);
                         if(copied == -1){
                                 close(inputHandle);
                                 close(outputHandle);

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -26,6 +26,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 #include <cstdarg>
 #include <cstring>
 #include <iostream>
+#include <algorithm>
 
 #include <unistd.h>
 #include <errno.h>
@@ -305,12 +306,42 @@ namespace Utils
 		close(output_handle);
 		return true;
 	}
+	
+	bool IsLinuxPathElementSeparator(char c){
+		return c == '/';
+	}
+	
+	bool isLinuxPathCharacter(char c){
+		return c != '/';
+	}
+	
+	std::string GetLastPathElement(const std::string &path){
+		using namespace std;
+		string::reverse_iterator end = find(path.rbegin(), path.rend(), isLinuxPathCharacter);
+		if(end == path.rend()){
+			return string('/');
+		}else{
+			string::reverse_iterator beg = find(end, path.rend(), IsLinuxPathElementSeparator);
+			--end;
+			if(beg == path.rend()){
+				return string(path.begin(), end.base());
+			}else{
+				--beg;
+				return string(beg.base(), end.base());
+			}
+		}
+	};
 
+	bool copyFolderNonRecursive(const std::string &sourceFolder, const std::string &destFolder, const std::string &folderName){
+		
+	}
+	
 	bool copyFolder(const std::string& sourceFolder, const std::string& destFolder)
 	{
-		LOG(LogLevel::Error) << "copyFolder() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
-		return false;
+		if(!TryCreateFolder(destFolder)){
+			return false;
+		}
+		copyFolderNonRecursive(
 	}
 
 	bool renameFolder(const std::string& sourceFolder, const std::string& destFolder)


### PR DESCRIPTION
Implemented a few linux specific methods in common_items/LinuxUtils.cpp:
- GetAllFilesInFolder
- GetAllFilesInFolderRecursive
- TryCopyFile
Implemented TryCopyFile with sendfile because this copies the file in kernel space, which is more efficient
That will cause compatibility issues for linux kernels pre version 2.2 / glibc 2.1 (released 2004).
If this is a problem, I will reimplement it with POSIX read/write functions.
I could also add both implementations using conditional compilation based on the linux header version preprocessor macro if desired.

Added a few helper functions for use in LinuxUtils methods only

Reorganized methods so that helper functions are declared before the others

As per previous comment, couldn't find the credit list, so I'll add to that next time :)