### PR TITLE
Implemented Linux copy/move/delete of files and folders

### DIFF
--- a/Vic2ToHoI4/Data_Files/ReadMe.txt
+++ b/Vic2ToHoI4/Data_Files/ReadMe.txt
@@ -46,6 +46,7 @@ Idhrendur		- Project Lead, Programming, Analysis
 thatsgerman		- Programming, Analysis
 jepaan			- Programming
 Hamiller78		- Programming
+barryvm			- Programming
 Italianajt		- Analysis, Data Files, QA
 Ordinary_Kraut	- Analysis, Data Files
 DasGuntLord01	- Analysis

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -591,7 +591,7 @@ namespace Utils
 		return "";
 	}
 
-	bool deleteFile(const std::string &file)
+	bool DeleteFile(const std::string &file)
 	{
 		if(unlink(file.c_str()) != 0)
 		{
@@ -619,7 +619,7 @@ namespace Utils
 		}
 	}
 
-	bool deleteEmptyFolder(const std::string &folder){
+	bool DeleteEmptyFolder(const std::string &folder){
 		if(rmdir(folder.c_str()) != 0)
 		{
 			LOG(LogLevel::Error) << "unable to delete folder " << folder;
@@ -691,7 +691,7 @@ namespace Utils
                                                         return false;
                                                 }
                                         }else{
-                                                if(!deleteFile(childPath)){
+                                                if(!DeleteFile(childPath)){
                                                         closedir(dir);
                                                         return false;
                                                 }
@@ -699,7 +699,7 @@ namespace Utils
                                 }
                         }
                         closedir(dir);
-                        return deleteEmptyFolder(folder);
+                        return DeleteEmptyFolder(folder);
                }
 	}
 

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -703,11 +703,27 @@ namespace Utils
                }
 	}
 
+	/*
+		Converts an UTF sequence to an ASCII string
+		Any code points outside the 7 bit ASCII range are replaced by '?'
+		This function does not differentiate between leading and trailing octets so codepoints outside ASCII range might result in multiple '?
+		As a result, the return value contains the same number of octets as the input.
+	*/
 	std::string convertUTF8ToASCII(std::string UTF8)
-	{
-		LOG(LogLevel::Error) << "convertUTF8ToASCII() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
+	{                
+	        using namespace std;
+        	string result(UTF8); 
+       		for(string::iterator i = result.begin(); i != result.end(); ++i)
+		{
+                	if((*i & 0x80) != 0)
+			{
+                        	*i = '?';
+                	}
+        	}
+        	return result;
 	}
+
+
 
 	std::string convertUTF8To8859_15(std::string UTF8)
 	{

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -511,13 +511,38 @@ namespace Utils
                 return CopyFolderAndFiles(sourceFolder, pathAndName.first, pathAndName.second);
         }
 
-
-
 	bool renameFolder(const std::string& sourceFolder, const std::string& destFolder)
 	{
-		LOG(LogLevel::Error) << "renameFolder() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
-		return false;
+        	if(rename(sourceFolder.c_str(), destFolder.c_str()) != 0)
+		{
+                	LOG(LogLevel::Error) << "unable to rename folder " << sourceFolder << " to " << destFolder;
+                	switch(errno)
+			{
+                	        case EACCES:
+                        	case EPERM:
+                        	        LOG(LogLevel::Error) << "no permission to move folder";
+                        	        break;
+                       		case ENOENT:
+                                	LOG(LogLevel::Error) << "source folder does not exist";
+                                	break;
+                        	case EBUSY:
+                                	LOG(LogLevel::Error) << "source or destination folder is locked by another process";
+                                	break;
+                        	case EEXIST:
+                        	case ENOTEMPTY:
+                                	LOG(LogLevel::Error) << "destination folder already exists and is not empty";
+                                	break;
+                        	case EINVAL:
+                                	LOG(LogLevel::Error) << "destination folder contains source folder";
+                                	break;
+                        	case EISDIR:
+                                	LOG(LogLevel::Error) << "destination folder is not a directory";
+                                	break;
+                	}
+        	        return false;
+        	}else{
+        	        return true;
+	        }
 	}
 
 	bool DoesFileExist(const std::string& path)


### PR DESCRIPTION
Implemented a few more functions in LinuxUtils.cpp:

- copyFolder
- renameFolder
- deleteFolder
- convertUTF8ToASCII

Added helper functions to delete files, normalize path's and 
fixed possible issues with ConcatenateNodeName and SplitNodeNameFromPath when given non-normalized input

Some questions: Should GetLastErrorString return the last error condition in the filesystem functions ?
If so, the result might be ambiguous, since many errno values have multiple meanings in different contexts and some may be set sequentially in a function call (copyFolder, deleteFolder). It might not be easy to track down where the error was raised from GetLastErrorString's output.

Also, copyFolder does not trace into hidden folders and does not copy hidden files at the moment, but could be trivially changed to do so. I'm not sure what the desired behaviour would be in this case.

Tested on Debian 8 and Linux Mint 17.2 (Ubuntu 14.04)