### PR TITLE
UTF16 wchar_t conversion functions

### DIFF
--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -754,8 +754,18 @@ namespace Utils
 	public:
 		explicit ConversionInputBuffer(const std::string &input) : data(new char[input.length()]), in_buffer(data), remainder(input.length())
 		{
+			using namespace std;
 			//POSIX iconv expects a pointer to char *, not to const char * and consequently does not guarantee that the input sequence is not modified so we copy it into the buffer before attempting conversion
 			copy(input.begin(), input.end(), data);
+		};
+		
+		template<typename Char, typename Traits, typename Alloc> explicit ConversionInputBuffer(const std::basic_string<Char,Traits,Alloc> &input){
+			using namespace std;
+			remainder = sizeof(Char) * input.length();
+			data = new char[remainder];
+			in_buffer = data;
+			const char *input_str = reinterpret_cast<const char *>(input.c_str());
+			copy(input_str, input_str + remainder, data);
 		};
 
 		~ConversionInputBuffer()

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -946,12 +946,18 @@ namespace Utils
 
 	std::string convertUTF8ToASCII(std::string UTF8)
 	{
-	        return ConvertString("ASCII","UTF-8", UTF8);
+	        using namespace std;
+		string result;
+		ConvertString("ASCII","UTF-8", UTF8, result);
+		return result;
 	}
 
 	std::string convertUTF8To8859_15(std::string UTF8)
 	{
-		return ConvertString("ISO−8859−15","UTF−8", UTF8);
+		using namespace std;
+		string result;
+		ConvertString("ISO−8859−15","UTF−8", UTF8, result);
+		return result;
 	}
 	
 	std::string convertUTF16ToUTF8(std::wstring UTF16)
@@ -962,7 +968,10 @@ namespace Utils
 
 	std::string convert8859_15ToUTF8(std::string input)
 	{
-		return ConvertString("UTF-8","ISO−8859−15", input);
+		using namespace std;
+		string result;
+		ConvertString("UTF-8","ISO−8859−15", input, result);
+		return result;
 	}
 
 	std::wstring convert8859_15ToUTF16(std::string UTF8)

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -778,7 +778,7 @@ namespace Utils
 			return remainder != 0;
 		};
 
-		friend bool ConvertString(const char *, const char *, ConversionInputBuffer &, ConversionOutputBuffer &); 
+		friend bool ConvertBuffer(const char *, const char *, ConversionInputBuffer &, ConversionOutputBuffer &); 
 	private:
 		//declared private to avoid copy of buffer
 		//unsure if versions pre c++11  should be supported, if not, copy constructors can be explicitly deleted
@@ -878,7 +878,7 @@ namespace Utils
 			return ensure_capacity(size+block_size);
 		};
 
-		friend bool ConvertString(const char *, const char *, ConversionInputBuffer &, ConversionOutputBuffer &);
+		friend bool ConvertBuffer(const char *, const char *, ConversionInputBuffer &, ConversionOutputBuffer &);
 	private:
 		//declared private to avoid copy of buffer
 		//unsure if versions pre c++11  should be supported, if not, copy constructors can be explicitly deleted
@@ -886,7 +886,7 @@ namespace Utils
 		ConversionOutputBuffer &operator=(const ConversionOutputBuffer &);
 	};
 
-	bool ConvertBuffer(const char *toCode, const char *fromCode, ConversionInputBuffer &from, ConversionOutputBuffer &to)
+	bool ConvertBuffer(const char *fromCode, const char *toCode, ConversionInputBuffer &from, ConversionOutputBuffer &to)
 	{
 		using namespace std;
 		iconv_t descriptor = iconv_open(toCode, fromCode);
@@ -926,7 +926,7 @@ namespace Utils
 	* member function size_t length() const
 	*
 	*/
-	template<typename InputString, typename OutputString> bool ConvertString(const char *toCode, const char *fromCode, const InputString &from, OutputString &to, std::size_t to_buffer_size = 0)
+	template<typename InputString, typename OutputString> bool ConvertString(const char *fromCode, const char *toCode, const InputString &from, OutputString &to, std::size_t to_buffer_size = 0)
 	{
 		using namespace std;
 		if(to_buffer_size == 0)
@@ -935,7 +935,7 @@ namespace Utils
 		}
 		ConversionInputBuffer from_buffer(from);
 		ConversionOutputBuffer to_buffer(to_buffer_size);
-		if(ConvertBuffer(toCode, fromCode, from_buffer, to_buffer))
+		if(ConvertBuffer(fromCode, toCode, from_buffer, to_buffer))
 		{
 			to_buffer.str(to);
 			return true;
@@ -943,53 +943,49 @@ namespace Utils
 			return false;
 		}
 	}
+	
+	template<typename InputString, typename OutputString> OutputString ConvertString(const char *fromCode, const char *toCode, const InputString &from, std::size_t to_buffer_size = 0)
+	{
+		using namespace std;
+		OutputString output;
+		ConvertString(fromCode, toCode, from output, to_buffer_size);
+		return output;
+	}
 
 	std::string convertUTF8ToASCII(std::string UTF8)
 	{
 	        using namespace std;
-		string result;
-		ConvertString("ASCII","UTF-8", UTF8, result);
-		return result;
+		return ConvertString<string, string>("UTF-8", "ASCII", UTF8);
 	}
 
 	std::string convertUTF8To8859_15(std::string UTF8)
 	{
 		using namespace std;
-		string result;
-		ConvertString("ISO−8859−15","UTF−8", UTF8, result);
-		return result;
+		return ConvertString<string, string>("UTF−8", "ISO−8859−15", UTF8)
 	}
 	
 	std::string convertUTF16ToUTF8(std::wstring UTF16)
 	{
 		using namespace std;
-		string result;
-		ConvertString("wchar_t","UTF−8", UTF8, result);
-		return result;
+		return ConvertString<wstring, string>("UTF−8", "wchar_t", UTF8);
 	}
 
 	std::string convert8859_15ToUTF8(std::string input)
 	{
 		using namespace std;
-		string result;
-		ConvertString("UTF-8","ISO−8859−15", input, result);
-		return result;
+		return ConvertString<string, string>("ISO−8859−15", "UTF-8", input);
 	}
 
 	std::wstring convert8859_15ToUTF16(std::string UTF8)
 	{
 		using namespace std;
-		wstring result;
-		ConvertString("ISO−8859−15","wchar_t", input, result);
-		return result;
+		return ConvertString<string, wstring>("wchar_t", "ISO−8859−15", UTF8);
 	}
 
 	std::wstring convertUTF8ToUTF16(std::string UTF8)
 	{
 		using namespace std;
-		wstring result;
-		ConvertString("UTF-8","wchar_t", input, result);
-		return result;
+		return ConvertString<string, wstring>("wchar_t", "UTF-8",UTF8);
 	}
 
 	int FromMultiByte(const char* in, size_t inSize, wchar_t* out, size_t outSize)

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -821,7 +821,7 @@ namespace Utils
 		};
 		
 	public:
-		explicit ConversionOutputBuffer(std::size_t initial_size = 0, std::size_t increment_block_size = 1024) : size(initial_size), remainder(initial_size), block_size(increment_block_size)
+		explicit ConversionOutputBuffer(std::size_t initial_size = 0, std::size_t increment_block_size = 1024*1024) : size(initial_size), remainder(initial_size), block_size(increment_block_size)
 		{
 			if(size != 0)
 			{ 
@@ -972,7 +972,7 @@ namespace Utils
 	std::string convertUTF16ToUTF8(std::wstring UTF16)
 	{
 		using namespace std;
-		return ConvertString<wstring, string>("UTF−8", "wchar_t", UTF16);
+		return ConvertString<wstring, string>("wchar_t", "UTF-8", UTF16);
 	}
 
 	std::string convert8859_15ToUTF8(std::string input)
@@ -989,7 +989,7 @@ namespace Utils
 	std::wstring convert8859_15ToUTF16(std::string UTF8)
 	{
 		using namespace std;
-		return ConvertString<string, wstring>("wchar_t", "ISO−8859−15", UTF8);
+		return ConvertString<string, wstring>("ISO−8859−15", "wchar_t", UTF8);
 	}
 
 	/*
@@ -1000,7 +1000,7 @@ namespace Utils
 	std::wstring convertUTF8ToUTF16(std::string UTF8)
 	{
 		using namespace std;
-		return ConvertString<string, wstring>("wchar_t", "UTF-8",UTF8);
+		return ConvertString<string, wstring>("UTF-8", "wchar_t",UTF8);
 	}
 
 	int FromMultiByte(const char* in, size_t inSize, wchar_t* out, size_t outSize)

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -759,7 +759,8 @@ namespace Utils
 			copy(input.begin(), input.end(), data);
 		};
 		
-		template<typename Char, typename Traits, typename Alloc> explicit ConversionInputBuffer(const std::basic_string<Char,Traits,Alloc> &input){
+		template<typename String> explicit ConversionInputBuffer(const String &input){
+			typedef typename String::value_type Char;
 			using namespace std;
 			remainder = sizeof(Char) * input.length();
 			data = new char[remainder];
@@ -964,6 +965,10 @@ namespace Utils
 		return ConvertString<string, string>("UTF−8", "ISO−8859−15", UTF8)
 	}
 	
+	/*
+		Warning: The input string should not be encoded in UTF-16 but in the system dependent wchar_t encoding
+		see convertUTF8ToUTF16 for full explanation
+	*/
 	std::string convertUTF16ToUTF8(std::wstring UTF16)
 	{
 		using namespace std;
@@ -976,12 +981,22 @@ namespace Utils
 		return ConvertString<string, string>("ISO−8859−15", "UTF-8", input);
 	}
 
+	/*
+		Warning: Does not actually return an UTF-16 sequence.
+		This is an implementation of the original Windows-based API which uses UTF-16 LE as the system dependent wchar_t encoding
+		This behaviour is replicated on Linux but it uses the (system dependent) wchar_t encoding.
+	*/
 	std::wstring convert8859_15ToUTF16(std::string UTF8)
 	{
 		using namespace std;
 		return ConvertString<string, wstring>("wchar_t", "ISO−8859−15", UTF8);
 	}
 
+	/*
+		Warning: Does not actually return an UTF-16 sequence.
+		This is an implementation of the original Windows-based API which uses UTF-16 LE as the system dependent wchar_t encoding
+		This behaviour is replicated on Linux but it uses the (system dependent) wchar_t encoding.
+	*/
 	std::wstring convertUTF8ToUTF16(std::string UTF8)
 	{
 		using namespace std;

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -962,8 +962,10 @@ namespace Utils
 	
 	std::string convertUTF16ToUTF8(std::wstring UTF16)
 	{
-		LOG(LogLevel::Error) << "convertUTF16ToUTF8() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
+		using namespace std;
+		string result;
+		ConvertString("wchar_t","UTF−8", UTF8, result);
+		return result;
 	}
 
 	std::string convert8859_15ToUTF8(std::string input)
@@ -976,14 +978,18 @@ namespace Utils
 
 	std::wstring convert8859_15ToUTF16(std::string UTF8)
 	{
-		LOG(LogLevel::Error) << "convert8859_15ToUTF16() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
+		using namespace std;
+		wstring result;
+		ConvertString("ISO−8859−15","wchar_t", input, result);
+		return result;
 	}
 
 	std::wstring convertUTF8ToUTF16(std::string UTF8)
 	{
-		LOG(LogLevel::Error) << "convertUTF8ToUTF16() has been stubbed out in LinuxUtils.cpp.";
-		exit(-1);
+		using namespace std;
+		wstring result;
+		ConvertString("UTF-8","wchar_t", input, result);
+		return result;
 	}
 
 	int FromMultiByte(const char* in, size_t inSize, wchar_t* out, size_t outSize)

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -852,7 +852,7 @@ namespace Utils
 		};
 
 		template<typename String> void str(String &output) const{
-			OutputStrHelper<String>::str(output, buffer, length());
+			OutputStrHelper<String>::str(output, data, length());
 		};
 
 		bool ensure_capacity(std::size_t capacity)
@@ -948,9 +948,9 @@ namespace Utils
 	template<typename InputString, typename OutputString> OutputString ConvertString(const char *fromCode, const char *toCode, const InputString &from, std::size_t to_buffer_size = 0)
 	{
 		using namespace std;
-		OutputString output;
-		ConvertString(fromCode, toCode, from output, to_buffer_size);
-		return output;
+		OutputString to;
+		ConvertString(fromCode, toCode, from, to, to_buffer_size);
+		return to;
 	}
 
 	std::string convertUTF8ToASCII(std::string UTF8)
@@ -962,7 +962,7 @@ namespace Utils
 	std::string convertUTF8To8859_15(std::string UTF8)
 	{
 		using namespace std;
-		return ConvertString<string, string>("UTF−8", "ISO−8859−15", UTF8)
+		return ConvertString<string, string>("UTF−8", "ISO−8859−15", UTF8);
 	}
 	
 	/*
@@ -972,7 +972,7 @@ namespace Utils
 	std::string convertUTF16ToUTF8(std::wstring UTF16)
 	{
 		using namespace std;
-		return ConvertString<wstring, string>("UTF−8", "wchar_t", UTF8);
+		return ConvertString<wstring, string>("UTF−8", "wchar_t", UTF16);
 	}
 
 	std::string convert8859_15ToUTF8(std::string input)


### PR DESCRIPTION
Initial implementation wchar_t conversions.
I've tested two approached to implement the UTF16 conversion functions:

- It's possible to encode to UTF-16 LE in Linux and then store the result in a wstring but on my system char_traits<wchar_t> assumes that wchar_t values are 4 octet UTF-8 sequences so most lexicographic string functions fail as do non binary wostream operations. It works on Windows because UTF-16 LE is the default wchar_t encoding.

- The second approach was to encode the output using the system dependent wchar_t encoding (UTF-8 in my case) and this seems to work as expected. The drawback is that the function name specifies that the input or output is an UTF-16 string while in reality it's an UTF-8 string.

I implemented the second approach and it seems to parse OK so far.
I've not yet been able to successfully convert one of the save games because I keep running into "missing Hearts Of iron 4/tfh directory" errors so I assume I'll have to look at the directory code again.

I've fixed two bugs in the already committed conversions so I created a new pull request.
If you'd rather wait until I tested the complete flow, feel free to reject the pull request.
In the meantime I'll test the conversion of the the save games in Vic2_Saves.