### PR TITLE
Initial version of portable parser

### DIFF
--- a/Vic2ToHoI4/CMakeLists.txt
+++ b/Vic2ToHoI4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 2.1)
 #set(CMAKE_VERBOSE_MAKEFILE on)
 
 project(Vic2ToHoI4)
@@ -22,8 +22,10 @@ set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/Date.cpp")
 set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/LinuxUtils.cpp")
 set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/Log.cpp")
 set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/Object.cpp")
-set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/ParadoxParser8859_15.cpp")
 set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/ParadoxParserUTF8.cpp")
+set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/ParadoxParser8859_15.cpp")
+set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/Encoding.cpp")
+set(COMMON_SOURCES ${COMMON_SOURCES} "../common_items/ParadoxParserGeneric.cpp")
 
 set(Boost_USE_STATIC_LIBS       OFF)
 set(Boost_USE_MULTITHREADED     OFF)

--- a/common_items/ConversionFacet.h
+++ b/common_items/ConversionFacet.h
@@ -1,0 +1,108 @@
+#ifndef CONVERSION_FACET_H
+#define CONVERSION_FACET_H
+
+#include <locale>
+
+#include "ConversionFacetUtils.h"
+#include "Encoding.h"
+
+namespace parser_generic{
+	
+	/*
+	* An implementation of the codecvt locale facet that converts between the supplied encodings and character types
+	* Warning: Most C++ standard library implementations only provide those specializations of codecvt_base required by the standard
+	* To be sure, only use the following specializations for ConversionFacet:
+	*  <char, char, mbstate_t> 
+	*  <wchar_t, char, mbstate_t> and <char, wchar_t, mbstate_t>
+	*  <char, char16_t, mbstate_t> and <char16_t, char, mbstate_t> (c++11 only)
+	*  <char, char32_t, mbstate_t> and <char32_t, char, mbstate_t> (c++11 only)
+	*
+	* If using this outside the context of a locale, remember to call unshift on each state used before deallocation of the facet to make sure no dangling state pointers are left behind
+	*/
+	template<typename InChar, typename ExChar, typename State = std::mbstate_t> class ConversionFacet : public std::codecvt<InChar, ExChar, State>{
+        public:
+                using Base = std::codecvt<InChar,ExChar, State>;
+                using result = typename Base::result;
+        private:
+
+                using Conversions = conversion_facet_utils::Conversions;	
+		using StateManager = conversion_facet_utils::StateManager<State>;
+		
+		mutable StateManager state_manager_;
+                bool always_noconv_;
+                int encoding_;
+                int max_length_;
+
+                static int calc_encoding(Encoding ex){
+                        if(ex->variable_length){
+                                return 0;
+                        }else{
+                                return ex->max_character_size / sizeof(ExChar);
+                        }
+                };
+
+                static int calc_max_length(Encoding in){
+                        return in->max_character_size / sizeof(InChar);
+                };
+	public:
+
+                ConversionFacet(Encoding external_encoding, Encoding internal_encoding) :
+                        state_manager_{internal_encoding, external_encoding},
+                        always_noconv_{internal_encoding == external_encoding},
+                        encoding_{calc_encoding(external_encoding)},
+                        max_length_{calc_max_length(internal_encoding)}{};
+        protected:
+
+                bool do_always_noconv() const noexcept{
+                        return always_noconv_;
+                };
+
+                int do_encoding() const noexcept{
+                        return encoding_;
+                };
+
+                int do_max_length() const noexcept{
+                        return max_length_;
+                };
+
+                result do_in(State &state, const ExChar *from, const ExChar *from_end, const ExChar * &from_next, InChar *to, InChar *to_end, InChar * &to_next) const{
+                        if(always_noconv_){
+                                return result::noconv;
+                        }
+                        Conversions *conversions = state_manager_.acquire(state);
+                        return conversions->ex_to_in.convert(from, from_end, from_next, to, to_end, to_next);
+                };
+
+                result do_out(State &state, const InChar *from, const InChar *from_end, const InChar *&from_next, ExChar *to, ExChar *to_end, ExChar *&to_next) const{
+                        if(always_noconv_){
+                                return result::noconv;
+                        }
+                        Conversions *conversions = state_manager_.acquire(state);
+                        return conversions->in_to_ex.convert(from, from_end, from_next, to, to_end, to_next);
+                };
+
+                int do_length(State &state, const ExChar *from, const ExChar *from_end, std::size_t max) const{
+                        Conversions *conversions = state_manager_.acquire(state);
+                        const ExChar *from_next;
+                        InChar to[max];
+                        InChar *to_next = to;
+                        result res = conversions->ex_to_in.convert(from, from_end, from_next, to, to+max, to_next);
+                        if(res == Base::ok || res == Base::partial){
+                                return static_cast<int>(from_next - from);
+                        }else{
+                                return max;
+                        }
+                };
+
+                result do_unshift(State &state, ExChar *to, ExChar *to_limit, ExChar *&to_next) const{
+                        to_next = to;
+                        Conversions *conversions = state_manager_.acquire(state);
+                        state_manager_.release(conversions, state);
+                        return Base::ok;
+                };
+
+        };
+
+}
+
+#endif

--- a/common_items/ConversionFacetUtils.h
+++ b/common_items/ConversionFacetUtils.h
@@ -209,7 +209,7 @@ namespace parser_generic{
                         };
 
                         StateManager(const StateManager<State> &) = delete;
-                        StateManager &operator=(const StateManager<State> &) = delete;
+                        StateManager<State> &operator=(const StateManager<State> &) = delete;
                 };
 
 		

--- a/common_items/ConversionFacetUtils.h
+++ b/common_items/ConversionFacetUtils.h
@@ -1,0 +1,209 @@
+
+/*
+	Do not include this header directly: include ConversionFacet.h instead
+	This header may be split into a Windows  and a Linux one should the code become too complicated to easily split
+	All OS-specific functions and handles for the codecvt facet are defined here
+*/
+
+#ifndef CONVERSION_FACET_UTILS_H
+#define CONVERSION_FACET_UTILS_H
+
+#include <locale>
+#include <unordered_map>
+#include <mutex>
+#include <stdexcept>
+#include <cwchar>
+#include <cstring>
+
+#ifdef __linux__
+
+#include <iconv.h>
+#include <errno.h>
+
+#endif
+
+#ifdef __WIN32__
+
+//TODO windows includes
+
+#endif
+
+#include "Encoding.h"
+
+namespace parser_generic{
+	
+	namespace conversion_facet_utils{
+
+#ifdef __linux__
+        
+                // The Linux specific conversion code 
+                class Conversion{
+                private:
+                        iconv_t descriptor_;
+                public:
+
+                        template<typename From, typename To> std::codecvt_base::result convert(const From *from, const From *from_end, const From * &from_next, To *to, To *to_end, To * &to_next) const{
+                                using namespace std;
+                                size_t from_remainder = static_cast<size_t>(from_end - from) * sizeof(From);
+                                size_t to_remainder = static_cast<size_t>(to_end - to) * sizeof(To);
+
+                                from_next = from;
+                                to_next = to;
+                                size_t conversion_result = iconv(descriptor_, (char **)(&from_next), &from_remainder, (char **)(&to_next),&to_remainder);
+                                if(conversion_result == ((size_t)(-1))){
+                                        switch(errno){
+                                                case EINVAL:
+                                                case E2BIG:
+                                                        return codecvt_base::partial;
+                                                default:        
+                                                        return codecvt_base::error;
+                                        }
+                                }else{
+                                        return codecvt_base::ok;
+                                }
+                        };
+        
+                        Conversion(Encoding from_encoding, Encoding to_encoding){
+                                using namespace std;
+                                const char *from_name = from_encoding->name.c_str();
+                                const char *to_name = to_encoding->name.c_str();
+                                descriptor_ = iconv_open(to_name, from_name);
+                                if(descriptor_ == ((iconv_t)(-1))){
+                                        throw invalid_argument{std::string{"unsupported conversion: "} + from_name + " -> " + to_name};
+                                }
+                        };
+ 
+                        ~Conversion(){
+                                iconv_close(descriptor_);
+                        };
+
+                        Conversion(const Conversion &) = delete;
+                        Conversion &operator=(const Conversion &) = delete;
+                };              
+#endif
+
+#ifdef __WIN32__
+
+                //TODO provide a Conversion object for windows
+                //This is the only OS specific part of the code
+
+                struct Conversion{
+                        Conversion(Encoding, Encoding){};
+
+                        template<typename From, typename To> std::codecvt_base::result convert(const From *from, const From *from_end, const From * &from_next, To *to, To *to_end, To * &to_next) const{
+                                return std::codecvt_base::error;
+                        };
+                };
+#endif
+
+        	//a pair of invertible conversions
+		struct Conversions{
+                        Conversion in_to_ex;
+                        Conversion ex_to_in;
+
+                        Conversions(Encoding in, Encoding ex) : in_to_ex{in, ex}, ex_to_in(ex, in){};
+
+                        Conversions(const Conversions &) = delete;
+                        Conversions &operator=(const Conversions &) = delete;
+                };
+
+		//An object that manages a link between external multi-byte states and an internal map of pointers
+		//This is done for two purposes:
+		// 1) To avoid exposing raw pointers to the outside world
+		// 2) To synchronize multi-threaded access to the facet's state if needed
+		//
+		template<typename State = std::mbstate_t> class StateManager{
+                private:
+
+                        using InternalState = std::size_t;
+
+                        const Encoding internal_encoding_;
+                        const Encoding external_encoding_;
+
+                        std::unordered_map<InternalState, Conversions *> data_;
+                        std::mutex mutex_;
+
+                        const InternalState empty_state_;
+                        InternalState next_state_;
+
+                        // The dirty bit
+                        static InternalState to_internal_state(State state){
+                                return *reinterpret_cast<InternalState *>(&state);
+                        };
+
+                        // even worse
+                        static void set_external_state(InternalState in_state, State &state){
+                                state = *reinterpret_cast<State *>(&in_state);
+                        };
+
+                        static InternalState create_initial_state(){
+                                std::mbstate_t state;
+                                memset(&state, 0, sizeof(std::mbstate_t));
+                                return to_internal_state(state);
+                        };
+
+                        Conversions *get(InternalState state){
+                                using namespace std;
+                                lock_guard<mutex> lock{mutex_};
+                                auto found = data_.find(state);
+                                return found == data_.end() ? nullptr : found->second;
+                        };
+
+                        void put(InternalState state, Conversions *conversions){
+                                using namespace std;
+                                lock_guard<mutex> lock{mutex_};
+                                data_.insert(make_pair(state, conversions));
+                        };
+
+                        void remove(InternalState state){
+                                using namespace std;
+                                lock_guard<mutex> lock{mutex_};
+                                auto found = data_.find(state);
+                                if(found != data_.end()){
+                                        data_.erase(found);
+                                }
+                        };
+
+                        InternalState next_state(){
+                                using namespace std;
+                                lock_guard<mutex> lock{mutex_};
+                                ++next_state_;
+                                return next_state_;
+                        };
+
+		public:
+                        StateManager(Encoding internal_encoding, Encoding external_encoding) : internal_encoding_{internal_encoding}, external_encoding_{external_encoding}, data_{}, mutex_{}, empty_state_{create_initial_state()}, next_state_{empty_state_}{};
+
+                        Conversions *acquire(State &state){
+                                InternalState in_state = to_internal_state(state);
+                                Conversions *conversions;
+                                if(in_state == empty_state_ || !(conversions = get(in_state))){
+                                        in_state = next_state();
+                                        conversions = new Conversions{internal_encoding_, external_encoding_};
+                                        set_external_state(in_state, state);
+                                }
+                                return conversions;
+                        };
+
+                        void release(Conversions *conversions, State &state){
+                                remove(to_internal_state(state));
+                                set_external_state(empty_state_, state);
+                                delete conversions;
+                        };
+
+                        ~StateManager(){
+                                for(auto pair : data_){
+                                        delete pair.second;
+                                }
+                        };
+
+                        StateManager(const StateManager<State> &) = delete;
+                        StateManager &operator=(const StateManager<State> &) = delete;
+                };
+
+		
+	};
+
+}
+
+#endif

--- a/common_items/Encoding.cpp
+++ b/common_items/Encoding.cpp
@@ -1,0 +1,42 @@
+#include "Encoding.h"
+
+using namespace parser_generic;
+
+// Use static variables inside functions to make sure only one 'instance' of each encoding is created and that it lives on until program shutdown
+
+Encoding create_ascii(){
+        static EncodingDescriptor encoding{"ASCII", false, 1};
+        return &encoding;
+};
+
+Encoding create_utf_8(){
+        static EncodingDescriptor encoding{"UTF-8", true, 4};
+        return &encoding;
+};
+
+Encoding create_utf_16_le(){
+        static EncodingDescriptor encoding{"UTF-16LE", true, 4};
+        return &encoding;
+};
+
+Encoding create_iso_8859_15(){
+        static EncodingDescriptor encoding{"ISO-8859-15", false, 1};
+        return &encoding;
+};
+
+Encoding create_ucs(){
+        static EncodingDescriptor encoding{"UCS-4-INTERNAL", false, 4};
+        return &encoding;
+};
+
+Encoding create_wchar_t(){
+        static EncodingDescriptor encoding{"wchar_t", false, sizeof(wchar_t)};
+        return &encoding;
+};
+
+const Encoding parser_generic::ASCII{create_ascii()};
+const Encoding parser_generic::UTF_8{create_utf_8()};
+const Encoding parser_generic::UTF_16_LE{create_utf_16_le()};
+const Encoding parser_generic::ISO_8859_15{create_iso_8859_15()};
+const Encoding parser_generic::WCHAR{create_wchar_t()};
+const Encoding parser_generic::UCS{create_ucs()};

--- a/common_items/Encoding.h
+++ b/common_items/Encoding.h
@@ -1,0 +1,43 @@
+#ifndef ENCODING_H
+#define ENCODING_H
+
+#include <string>
+
+namespace parser_generic{
+
+	
+	/*
+	* A struct containing the necessary info to determine character length
+	* Should never be copied or created, use Encoding instead
+	*/        
+        struct EncodingDescriptor{
+                const std::string name;
+                const bool variable_length;
+                const std::size_t max_character_size;
+                                
+                EncodingDescriptor(const std::string &name_, bool variable_length_, std::size_t max_character_size_) : name{name_}, variable_length{variable_length_}, max_character_size{max_character_size_}{};
+        };
+
+        //Should be considered an opaque type, use only to tag which encoding to use
+	using Encoding = const EncodingDescriptor *;
+        
+        //7 bit ASCII encoding
+        extern const Encoding ASCII;
+
+        //UTF-8 encoding (limited to 4 bytes)
+        extern const Encoding UTF_8;
+
+        //ISO 8859 15 encoding
+        extern const Encoding ISO_8859_15;
+
+        //UTF-16 little endian encoding
+        extern const Encoding UTF_16_LE;
+
+        //native system encoding for wchar_t
+        extern const Encoding WCHAR;
+
+        //UCS (4 byte unicode codepoint) currently not used but may be usefull for debugging (code points are well defined values, unlike wchar_t)
+        extern const Encoding UCS;
+}
+
+#endif

--- a/common_items/LinuxUtils.cpp
+++ b/common_items/LinuxUtils.cpp
@@ -1052,28 +1052,10 @@ namespace Utils
 		return ConvertString<string, wstring>("UTF-8", "wchar_t",UTF8);
 	}
 
-	int FromMultiByte(const char* in, size_t inSize, wchar_t* out, size_t outSize)
+	
+	std::string convertToUTF8(const std::wstring &input)
 	{
-		/*if(outSize == 0)
-			return inSize;
-
-		if(inSize <= outSize)
-			memcpy(out, in, inSize);
-
-		/*iconv_t conv = iconv_open("CP1252", "UTF-16");
-		iconv(conv, &in, &inSize, (char*)&out, &outSize);
-		iconv_close(conv);*/
-	}
-
-	int ToMultiByte(const wchar_t* in, size_t inSize, char* out, size_t outSize)
-	{
-		/*if(outSize == 0)
-			return inSize;
-
-		if(inSize <= outSize)
-			memcpy(out, in, inSize);
-		/*iconv_t conv = iconv_open("UTF-16", "CP1252");
-		iconv(conv, (char*)&in, &inSize, &out, &outSize);
-		iconv_close(conv);*/
+		using namespace std;
+		return ConvertString<wstring, string>("wchar_t", "UTF-8",input);
 	}
 }

--- a/common_items/OSCompatibilityLayer.h
+++ b/common_items/OSCompatibilityLayer.h
@@ -109,6 +109,10 @@ namespace Utils
 	std::string convert8859_15ToUTF8(std::string input);
 	std::wstring convert8859_15ToUTF16(std::string UTF8);
 	std::wstring convertUTF8ToUTF16(std::string UTF8);
+
+	// converts a string in the system dependent wchar_t encoding to UTF-8
+	std::string convertToUTF8(const std::wstring &input);
+
 } // namespace Utils
 
 

--- a/common_items/ParadoxParser8859_15.cpp
+++ b/common_items/ParadoxParser8859_15.cpp
@@ -48,6 +48,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 #include "Log.h"
 #include "OSCompatibilityLayer.h"
 
+#include "ParadoxParserGenericSupport.h"
+
 using namespace boost::spirit;
 
 namespace parser_8859_15
@@ -445,6 +447,11 @@ namespace parser_8859_15
 
 	Object* doParseFile(string filename)
 	{
+// This switch is made to ensure no problems arise with the other projects
+// While the Generic parser is still being tested it will only be used on Linux (where USE_GENERIC_PARADOX_PARSER is set to 1 by default)
+// On Windows, it can be enabled from CMake / VC++ compiler args to test it
+#ifdef USE_GENERIC_PARADOX_PARSER
+
 		/* - when using parser debugging, also ensure that the parser object is non-static!
 		debugme = false;
 		if (string(filename) == "D:/Victoria 2/technologies/commerce_tech.txt")
@@ -463,5 +470,8 @@ namespace parser_8859_15
 		read.clear();
 
 		return obj;
+#else
+		return parser_generic::parseISO_8859_15(filename);
+#endif
 	}
 } // namespace parser_8859_15

--- a/common_items/ParadoxParser8859_15.cpp
+++ b/common_items/ParadoxParser8859_15.cpp
@@ -451,7 +451,8 @@ namespace parser_8859_15
 // While the Generic parser is still being tested it will only be used on Linux (where USE_GENERIC_PARADOX_PARSER is set to 1 by default)
 // On Windows, it can be enabled from CMake / VC++ compiler args to test it
 #ifdef USE_GENERIC_PARADOX_PARSER
-
+		return parser_generic::parseISO_8859_15(filename);
+#else
 		/* - when using parser debugging, also ensure that the parser object is non-static!
 		debugme = false;
 		if (string(filename) == "D:/Victoria 2/technologies/commerce_tech.txt")
@@ -470,8 +471,6 @@ namespace parser_8859_15
 		read.clear();
 
 		return obj;
-#else
-		return parser_generic::parseISO_8859_15(filename);
 #endif
 	}
 } // namespace parser_8859_15

--- a/common_items/ParadoxParserGeneric.cpp
+++ b/common_items/ParadoxParserGeneric.cpp
@@ -1,0 +1,128 @@
+#include "ParadoxParserGeneric.h"
+
+#include <fstream>
+#include <locale>
+
+#include <boost/bind.hpp>
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/support_istream_iterator.hpp>
+
+using namespace parser_generic;
+
+Object *parser_generic::parseUTF_8(const std::string &file_path){
+	return parse(file_path, UTF_8);
+}
+
+Object *parser_generic_parseISO_8859_15(const std::string &file_path){
+	return parse(file_path, ISO_8859_15);
+}
+
+Object *parser_generic::parse(const std::string &file_path, Encoding file_encoding){
+	using namespace std;
+	
+	//open the file as a wide character stream
+	basic_ifstream<wchar_t> input{file_path};
+
+	//create a new local based on the old one, but using the codecvt facet to decode the file encoding to the system dependant WCHAR encoding
+	locale loc{input.getloc(), new ConversionFacet<wchar_t,char>{file_encoding, WCHAR}};
+	
+	/*
+	input will now interpret the file as encoded by the specified encoding and transform the output into wide characters using the system dependentencoding
+	this will be UCS (4 byte codepoints) in most linux distro's and UTF-16 LE on windows
+	because the system encoding is not specifically named, the parser is portable if the ConversionFacet codecvt facet is implemented on all target systems
+	*/
+	input.imbue(loc);
+
+	//delegate to parse, which won't need to care about the encoding anymore 
+	return parse(input);	
+}
+
+// forward declaration of the parse function to keep things clean
+template<typename Iterator> Object *do_parse(Iterator begin, Iterator end);
+
+Object *parser_generic::parse(std::basic_istream<wchar_t> &input){
+	
+	/*
+	use boost's istream_iterator to directly couple the istream to the parser
+	this makes sure we can parse the entire file without preparsing it into objects and buffering each one (bufferNextObject will no longer be needed)
+	note that the entire file is not loaded into memory, and all buffering is done in istream's buffers
+	*/
+	boost::spirit::basic_istream_iterator<wchar_t> begin(input);
+        boost::spirit::basic_istream_iterator<wchar_t> end;		
+	
+	do_parse(begin, end);
+}
+
+/*
+	TODO: implement the parser properly by porting the grammar from ISO8859_15 parser
+	The current parser is a dummy that doesn't really do anything yet but demonstrate the eventual code
+	Note that the parser uses the system dependent wchar_t encoding but is still portable because the actual decoding of the files is done elsewhere
+*/
+
+namespace qi = boost::spirit::qi;
+
+namespace parsers = qi::standard_wide;
+
+const wchar_t QUOTE = L'"';
+
+const wchar_t ASSIGNMENT = L'=';
+
+const wchar_t OBJECT_START = L'{';
+
+const wchar_t OBJECT_END = L'}';
+
+const wchar_t COMMENT = L'#';
+
+//DUMMY
+void print(const std::wstring &str){
+        using namespace std;
+        cout << "quoted string: \"";
+        for(wchar_t c : str){
+                cout << static_cast<int>(c) << " ";
+        }
+        cout << '\"'<< endl;
+};
+
+//DUMMY
+template<typename Iterator> class Grammar : public qi::grammar<Iterator, std::wstring()>{
+private:
+
+        qi::rule<Iterator, std::wstring()> quoted_string_;
+
+public:
+        Grammar() : Grammar::base_type(quoted_string_){
+                using parsers::char_;
+                using parsers::space;
+                using parsers::graph;
+
+                quoted_string_ = (QUOTE >> *(char_ - QUOTE) >> QUOTE);
+
+        };
+
+};
+
+//DUMMY
+template<typename Iterator> Object *do_parse(Iterator begin, Iterator end){
+        using namespace std;
+
+        using qi::rule;
+        using qi::parse;
+
+        using parsers::char_;
+        using parsers::space;
+        using parsers::graph;
+
+        Grammar<Iterator> grammar;
+
+        wstring str;
+
+        bool result = true;
+        while(result){
+                result = parse(begin, end, grammar, str);
+                cout << "result: " << result << endl;
+                if(result){
+                        print(str);
+                }
+        }
+	return nullptr;
+};

--- a/common_items/ParadoxParserGeneric.h
+++ b/common_items/ParadoxParserGeneric.h
@@ -1,0 +1,23 @@
+#ifndef PARADOX_PARSER_GENERIC_H
+#define PARADOX_PARSER_GENERIC_H
+
+#include <string>
+#include <iostream>
+
+#include "Encoding.h"
+#include "ConversionFacet.h"
+#include "Object.h"
+
+namespace parser_generic{
+
+	Object *parse(std::basic_istream<wchar_t> &input);
+
+	Object *parse(const std::string &file_path, Encoding file_encoding);
+
+	Object *parseUTF_8(const std::string &file_path);
+
+	Object *parseISO_8859_15(const std::string &path);
+
+}
+
+#endif

--- a/common_items/ParadoxParserGenericSupport.h
+++ b/common_items/ParadoxParserGenericSupport.h
@@ -1,0 +1,25 @@
+#ifndef PARADOX_PARSER_GENERIC_SWITCH_H
+#define PARADOX_PARSER_GENERIC_SWITCH_H
+
+/*
+* The preprocessor define USE_GENERIC_PARADOX_PARSER controls whether all parsing is delegated to the generic parser
+* Defining USE_GENERIC_PARADOX_PARSER will cause both ParadoxParserUTF8 and ParadoxParser8859_15 (both of which are not portable to linux at this point) to delegate all parsing to the generic parser
+* Currently, USE_GENERIC_PARADOX_PARSER is set to 1 by default on linux builds, while Windows builds use the windows specific parsers
+* Testing of the generic parser on windows can then be enabled by setting USE_GENERIC_PARADOX_PARSER on the compiler command line or using cmake
+* The generic parser is currently implemented only on linux and is still a dummy but is designed to be portable to both Windows and linux
+* It should also be able to handle all encodings used in Paradox game files
+*/
+
+#ifdef __linux__
+
+#define USE_GENERIC_PARADOX_PARSER 1
+
+#endif
+
+#ifdef USE_GENERIC_PARADOX_PARSER
+
+#include "ParadoxParserGeneric.h"
+
+#endif
+
+#endif

--- a/common_items/ParadoxParserUTF8.cpp
+++ b/common_items/ParadoxParserUTF8.cpp
@@ -48,7 +48,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 #include <boost/spirit/include/qi.hpp>
 #include "Log.h"
 
-
+#include "ParadoxParserGenericSupport.h"
 
 using namespace boost::spirit;
 
@@ -429,6 +429,12 @@ namespace parser_UTF8
 
 	Object* doParseFile(string filename)
 	{
+// This switch is made to ensure no problems arise with the other projects
+// While the Generic parser is still being tested it will only be used on Linux (where USE_GENERIC_PARADOX_PARSER is set to 1 by default)
+// On Windows, it can be enabled from CMake / VC++ compiler args to test it
+#ifdef USE_GENERIC_PARADOX_PARSER
+		return parser_generic::parseUTF_8(filename);
+#else
 		/* - when using parser debugging, also ensure that the parser object is non-static!
 		debugme = false;
 		if (string(filename) == "D:/Victoria 2/technologies/commerce_tech.txt")
@@ -448,5 +454,6 @@ namespace parser_UTF8
 		read.clear();
 
 		return obj;
+#endif
 	}
 } // namespace parser_UTF8

--- a/common_items/WinUtils.cpp
+++ b/common_items/WinUtils.cpp
@@ -368,6 +368,10 @@ std::wstring convertUTF8ToUTF16(std::string UTF8)
 	return returnable;
 }
 
+std::string convertToUTF8(const std::wstring &input){
+	return convertUTF16ToUTF8(input);
+}
+
 
 void WriteToConsole(LogLevel level, const std::string& logMessage)
 {


### PR DESCRIPTION
I implemented a portable parser that should work on both Linux and Windows.
To minimize potential conflicts and issues, I did the following:

- ParadoxParserUTF8 and ParadoxParser8859_15 delegate to the generic parser only if the USE_GENERIC_PARADOX_PARSER preprocessor define is defined.

- The generic parser's headers are only included if the USE_GENERIC_PARADOX_PARSER preprocessor define is defined.

- USE_GENERIC_PARADOX_PARSER is only enabled by default in Linux.

After Linux conversion completes successfully, I'll need to implement a Windows version of the codecvt facet and test the parser on Windows as well. In the meantime, Windows builds have the option to use the generic parser but by default use the current parsers.

Changes:
- Added Encoding.h header that contains flags to denote a file encoding.
- Added ConversionFacet.h header that contains an implementation of the codecvt facet. OS-specific code has been moved to ConversionFacetUtils.h and the Windows version is still stubbed.
- Created a new"ParadoxParserGeneric.h" header that contains definitions of the public parser functions. This header can, in future, be used to trigger parsing of all types of files in all encodings and OS's.

Parser code:
- Decoding of the input is now done by the istream itself (using the ConversionFacet). The parser uses the wchar_t encoding (boost spirit 2 has only partial support of Unicode) and can be used on all file encodings used by Paradox. I also got rid of the 0x8* constants in the grammar that were used to have the parser accept UTF-8 octets because they are not needed any more (one wchar_t = one character => yay! )

- Made a new grammar loosely based on the ISO-8859-15 grammar and some browsing of the game files but implemented as a non skipping grammar. This cuts back on the lexeme and raw directives and makes the grammar clearer. 

- Implemented the parser as a stateless grammar (lexer) coupled to a statefull parser, which should make the parser thread- and exception safe. 

- got rid of all the buffering in the previous version. The istream is now connected directly to the parser and the file doesn't have to be split into objects any more either. On my machine at least, the performance gain is dramatic for large files.

The parser seems to work as expected so far, the no such invention errors caused by "Jean Jaurès" are now gone. The next error I'll fix is caused by a failure of the conversion function for a path name (UTF8 path -> ASCII path). This fails because some UTF-8 characters in the path cannot be represented in ASCII (which is technically correct, only not desired behaviour).

Feel free to ignore or reject this pull request if you are unsure about the changes, or want me to test it more beforehand. I'll just keep testing and adding fixes to it to get the actual export output done.
