### PR TITLE
Changed HoI4Country::outputPuppets()

### DIFF
--- a/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
+++ b/Vic2ToHoI4/Source/HOI4World/HoI4Country.cpp
@@ -1348,16 +1348,36 @@ void HoI4Country::outputPuppets(ofstream& output) const
 		output << "    }\n";
 		for (auto puppet : puppets)
 		{
-			output << "    set_autonomy = {\n";
-			output << "        target = " << puppet << "\n";
-			output << "        autonomous_state = autonomy_dominion\n";
-			output << "        freedom_level = 0.4\n";
-			output << "    }\n";
+			if (governmentIdeology == "fascism")
+			{
+				output << "    set_autonomy = {\n";
+				output << "        target = " << puppet << "\n";
+				output << "        autonomous_state = autonomy_integrated_puppet\n";
+				output << "    }\n";
+			}
+			else
+			{
+				output << "    set_autonomy = {\n";
+				output << "        target = " << puppet << "\n";
+				output << "        autonomous_state = autonomy_dominion\n";
+				output << "        freedom_level = 0.4\n";
+				output << "    }\n";
+			}
 		}
 		output << "    else = {\n";
 		for (auto puppet : puppets)
 		{
-			output << "        puppet = " << puppet << "\n";
+			if (governmentIdeology == "fascism")
+			{
+				output << "        set_autonomy = {\n";
+				output << "            target = " << puppet << "\n";
+				output << "            autonomous_state = autonomy_puppet << \n";
+				output << "        }\n";
+			}
+			else
+			{
+				output << "        puppet = " << puppet << "\n";
+			}
 		}
 		output << "    }\n";
 		output << "}\n";


### PR DESCRIPTION
Now discriminates between fascist and no-fascist states. Fascist states get entries like Japan in normal HoI4. I could use a Vic2 save file with a fascist nation with puppet states for testing...