### PR TITLE
Reduce log warning spam

### DIFF
--- a/EU4toV2/Source/EU4World/EU4Country.cpp
+++ b/EU4toV2/Source/EU4World/EU4Country.cpp
@@ -195,14 +195,17 @@ EU4Country::EU4Country(Object* obj, EU4Version* version)
 		date hundredYearsOld = date("1740.1.1");							// one hundred years before conversion
 		for (vector<Object*>::iterator itr = historyLeaves.begin(); itr != historyLeaves.end(); ++itr)
 		{
-			// grab leaders from history, ignoring those that are more than 100 years old...
-			if (date((*itr)->getKey()) > hundredYearsOld)
+			if(((*itr)->getKey()).find(".") != -1)	//historyObj contains some non-date leaves for initial config. Avoid trying to parse them as dates.
 			{
-				vector<Object*> leaderObjs = (*itr)->getValue("leader");	// the leaders in this history
-				for (vector<Object*>::iterator litr = leaderObjs.begin(); litr != leaderObjs.end(); ++litr)
+				// grab leaders from history, ignoring those that are more than 100 years old...
+				if (date((*itr)->getKey()) > hundredYearsOld)
 				{
-					EU4Leader* leader = new EU4Leader(*litr);	// a new leader
-					leaders.push_back(leader);
+					vector<Object*> leaderObjs = (*itr)->getValue("leader");	// the leaders in this history
+					for (vector<Object*>::iterator litr = leaderObjs.begin(); litr != leaderObjs.end(); ++litr)
+					{
+						EU4Leader* leader = new EU4Leader(*litr);	// a new leader
+						leaders.push_back(leader);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Country history contains some top-level tags that are not dates, reflecting intial-status conditions and other non-time-sensitive things. The parser, while looking for active leaders, was trying to interpret these as dates anyway, and throwing a good deal of warnings in the process.

This fix does not change functionality - the misparsed tags were immediately getting discarded anyway due to being interpreted (through error) as date 0.0.0, which is long before the cutoff used in this function.

Fixes #311.