### PR TITLE
Codification code fixing

### DIFF
--- a/Vic2ToHoI4/Source/Mappers/V2Localisations.cpp
+++ b/Vic2ToHoI4/Source/Mappers/V2Localisations.cpp
@@ -80,7 +80,7 @@ void V2Localisations::ReadFromFile(const string& fileName)
 }
 
 
-const string languages[] = { "english", "french", "german", "", "spanish" };
+const string languages[] = { "english", "french", "german", "polish", "spanish", "italian", "swedish", "czech", "hungarian", "dutch", "portugese", "russian", "finnish" };
 void V2Localisations::processLine(string line)
 {
 	int division = line.find_first_of(';');
@@ -111,20 +111,44 @@ string V2Localisations::getNextLocalisation(string line, int& division)
 
 string V2Localisations::replaceBadCharacters(string localisation)
 {
-	// � gets translated to an invalid character sequence. :-(
-	int O = localisation.find_first_of('�');
+	// Ö gets translated to an invalid character sequence. Oe is accepted substitute in German.
+	int O = localisation.find_first_of('Ö');
 	while (O != string::npos)
 	{
-		localisation.replace(O, 1, "O");
-		O = localisation.find_first_of('�');
+		localisation.replace(O, 1, "Oe");
+		O = localisation.find_first_of('Ö');
 	}
 
 	// dash characters other than 0x2D break HoI4
-	int dash = localisation.find_first_of('�');
+	int dash = localisation.find_first_of('–');
 	while (dash != string::npos)
 	{
 		localisation.replace(dash, 1, "-");
-		dash = localisation.find_first_of('�');
+		dash = localisation.find_first_of('–');
+	}
+
+	// Problem with S-hacek
+	int shacek = localisation.find_first_of('');
+	while (shacek != string::npos)
+	{
+		localisation.replace(shacek, 1, "š");
+		shacek = localisation.find_first_of('');
+	}
+
+	// Problem with Z-hacek
+	int zhacek = localisation.find_first_of('');
+	while (zhacek != string::npos)
+	{
+		localisation.replace(zhacek, 1, "ž");
+		zhacek = localisation.find_first_of('');
+	}
+
+	// Problem with apostrophe (Spanish)
+	int dash = localisation.find_first_of('');
+	while (dash != string::npos)
+	{
+		localisation.replace(dash, 1, "'");
+		dash = localisation.find_first_of('');
 	}
 
 	return localisation;

--- a/Vic2ToHoI4/Source/Mappers/V2Localisations.cpp
+++ b/Vic2ToHoI4/Source/Mappers/V2Localisations.cpp
@@ -144,11 +144,11 @@ string V2Localisations::replaceBadCharacters(string localisation)
 	}
 
 	// Problem with apostrophe (Spanish)
-	int dash = localisation.find_first_of('');
-	while (dash != string::npos)
+	int apostrophe = localisation.find_first_of('');
+	while (apostrophe != string::npos)
 	{
-		localisation.replace(dash, 1, "'");
-		dash = localisation.find_first_of('');
+		localisation.replace(apostrophe, 1, "'");
+		apostrophe = localisation.find_first_of('');
 	}
 
 	return localisation;


### PR DESCRIPTION
Fixing #430, making Ö turn into Oe (as German rules), and also adding more source-languages for Vic2 (whether they work or not).